### PR TITLE
Fix setup.py missing comma in setup() args

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     install_requires=[
         'gym>=0.24.0',
         "numpy>=1.18.0"
-    ]
+    ],
     classifiers=[
     "Development Status :: 5 - Production/Stable",
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
`setup.py` is currently broken due to a syntax error (missing comma between the `install_requires` and `classifiers` fields). This PR fixes that.