### PR TITLE
Fix Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-  - "3.5"
+  - "3.7"
 
 # command to install dependencies
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
 
 # command to install dependencies
 install:
-  - pip3 install -e .
+  - pip3 install .
 
 # command to run tests
 script: ./run_tests.py

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     name='gym_minigrid',
     author="Farama Foundation",
     author_email="jkterry@farama.org",
-    version='1.0.2',
+    version='1.1.0',
     keywords='memory, environment, agent, rl, gym',
     url='https://github.com/Farama-Foundation/gym-minigrid',
     description='Minimalistic gridworld reinforcement learning environments',
@@ -24,7 +24,7 @@ setup(
     python_requires=">=3.7, <3.11",
     long_description_content_type="text/markdown",
     install_requires=[
-        'gym>=0.24.0',
+        'gym==0.23',
         "numpy>=1.18.0"
     ],
     classifiers=[


### PR DESCRIPTION
Travis was failing for a number of results
1. It was using python 3.5 which hasn't been supported in a while and means that a very old version of gym was being used
2. Updating to python 3.7, oldest maintained version of python, causes the latest version of gym to throw errors, therefore, downgrade to gym v0.23 which doesn't cause issues