### PR TITLE
Compatibility old gym versions, v25, v24, v23, and v22

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Minimalistic Gridworld Environment (MiniGrid)
 
-[![Build Status](https://travis-ci.org/maximecb/gym-minigrid.svg?branch=master)](https://travis-ci.org/maximecb/gym-minigrid)
+[![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://pre-commit.com/) [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 
 There are other gridworld Gym environments out there, but this one is
 designed to be particularly simple, lightweight and fast. The code has very few

--- a/gym_minigrid/benchmark.py
+++ b/gym_minigrid/benchmark.py
@@ -18,7 +18,7 @@ parser.add_argument("--num_resets", default=200)
 parser.add_argument("--num_frames", default=5000)
 args = parser.parse_args()
 
-env = gym.make(args.env_name, render_mode="rgb_array")
+env = gym.make(args.env_name)
 
 # Benchmark env.reset
 t0 = time.time()

--- a/gym_minigrid/envs/blockedunlockpickup.py
+++ b/gym_minigrid/envs/blockedunlockpickup.py
@@ -1,4 +1,4 @@
-from gym_minigrid.minigrid import Ball
+from gym_minigrid.minigrid import COLOR_NAMES, Ball, MissionSpace
 from gym_minigrid.roomgrid import RoomGrid
 
 
@@ -10,7 +10,12 @@ class BlockedUnlockPickupEnv(RoomGrid):
 
     def __init__(self, **kwargs):
         room_size = 6
+        mission_space = MissionSpace(
+            mission_func=lambda color, type: f"pick up the {color} {type}",
+            ordered_placeholders=[COLOR_NAMES, ["box", "key"]],
+        )
         super().__init__(
+            mission_space=mission_space,
             num_rows=1,
             num_cols=2,
             room_size=room_size,

--- a/gym_minigrid/envs/crossing.py
+++ b/gym_minigrid/envs/crossing.py
@@ -2,7 +2,7 @@ import itertools as itt
 
 import numpy as np
 
-from gym_minigrid.minigrid import Goal, Grid, Lava, MiniGridEnv
+from gym_minigrid.minigrid import Goal, Grid, Lava, MiniGridEnv, MissionSpace
 
 
 class CrossingEnv(MiniGridEnv):
@@ -13,7 +13,19 @@ class CrossingEnv(MiniGridEnv):
     def __init__(self, size=9, num_crossings=1, obstacle_type=Lava, **kwargs):
         self.num_crossings = num_crossings
         self.obstacle_type = obstacle_type
+
+        mission_space = (
+            MissionSpace(
+                mission_func=lambda: "avoid the lava and get to the green goal square"
+            )
+            if self.obstacle_type == Lava
+            else MissionSpace(
+                mission_func=lambda: "find the opening and get to the green goal square"
+            )
+        )
+
         super().__init__(
+            mission_space=mission_space,
             grid_size=size,
             max_steps=4 * size * size,
             # Set this to True for maximum speed

--- a/gym_minigrid/envs/crossing.py
+++ b/gym_minigrid/envs/crossing.py
@@ -14,15 +14,14 @@ class CrossingEnv(MiniGridEnv):
         self.num_crossings = num_crossings
         self.obstacle_type = obstacle_type
 
-        mission_space = (
-            MissionSpace(
+        if obstacle_type == Lava:
+            mission_space = MissionSpace(
                 mission_func=lambda: "avoid the lava and get to the green goal square"
             )
-            if self.obstacle_type == Lava
-            else MissionSpace(
+        else:
+            mission_space = MissionSpace(
                 mission_func=lambda: "find the opening and get to the green goal square"
             )
-        )
 
         super().__init__(
             mission_space=mission_space,

--- a/gym_minigrid/envs/distshift.py
+++ b/gym_minigrid/envs/distshift.py
@@ -1,4 +1,4 @@
-from gym_minigrid.minigrid import Goal, Grid, Lava, MiniGridEnv
+from gym_minigrid.minigrid import Goal, Grid, Lava, MiniGridEnv, MissionSpace
 
 
 class DistShiftEnv(MiniGridEnv):
@@ -20,7 +20,12 @@ class DistShiftEnv(MiniGridEnv):
         self.goal_pos = (width - 2, 1)
         self.strip2_row = strip2_row
 
+        mission_space = MissionSpace(
+            mission_func=lambda: "get to the green goal square"
+        )
+
         super().__init__(
+            mission_space=mission_space,
             width=width,
             height=height,
             max_steps=4 * width * height,

--- a/gym_minigrid/envs/doorkey.py
+++ b/gym_minigrid/envs/doorkey.py
@@ -1,4 +1,4 @@
-from gym_minigrid.minigrid import Door, Goal, Grid, Key, MiniGridEnv
+from gym_minigrid.minigrid import Door, Goal, Grid, Key, MiniGridEnv, MissionSpace
 
 
 class DoorKeyEnv(MiniGridEnv):
@@ -9,7 +9,10 @@ class DoorKeyEnv(MiniGridEnv):
     def __init__(self, size=8, **kwargs):
         if "max_steps" not in kwargs:
             kwargs["max_steps"] = 10 * size * size
-        super().__init__(grid_size=size, **kwargs)
+        mission_space = MissionSpace(
+            mission_func=lambda: "use the key to open the door and then get to the goal"
+        )
+        super().__init__(mission_space=mission_space, grid_size=size, **kwargs)
 
     def _gen_grid(self, width, height):
         # Create an empty grid

--- a/gym_minigrid/envs/dynamicobstacles.py
+++ b/gym_minigrid/envs/dynamicobstacles.py
@@ -2,7 +2,7 @@ from operator import add
 
 import gym
 
-from gym_minigrid.minigrid import Ball, Goal, Grid, MiniGridEnv
+from gym_minigrid.minigrid import Ball, Goal, Grid, MiniGridEnv, MissionSpace
 
 
 class DynamicObstaclesEnv(MiniGridEnv):
@@ -21,7 +21,13 @@ class DynamicObstaclesEnv(MiniGridEnv):
             self.n_obstacles = int(n_obstacles)
         else:
             self.n_obstacles = int(size / 2)
+
+        mission_space = MissionSpace(
+            mission_func=lambda: "get to the green goal square"
+        )
+
         super().__init__(
+            mission_space=mission_space,
             grid_size=size,
             max_steps=4 * size * size,
             # Set this to True for maximum speed

--- a/gym_minigrid/envs/empty.py
+++ b/gym_minigrid/envs/empty.py
@@ -1,4 +1,4 @@
-from gym_minigrid.minigrid import Goal, Grid, MiniGridEnv
+from gym_minigrid.minigrid import Goal, Grid, MiniGridEnv, MissionSpace
 
 
 class EmptyEnv(MiniGridEnv):
@@ -10,7 +10,12 @@ class EmptyEnv(MiniGridEnv):
         self.agent_start_pos = agent_start_pos
         self.agent_start_dir = agent_start_dir
 
+        mission_space = MissionSpace(
+            mission_func=lambda: "get to the green goal square"
+        )
+
         super().__init__(
+            mission_space=mission_space,
             grid_size=size,
             max_steps=4 * size * size,
             # Set this to True for maximum speed

--- a/gym_minigrid/envs/fetch.py
+++ b/gym_minigrid/envs/fetch.py
@@ -1,4 +1,11 @@
-from gym_minigrid.minigrid import COLOR_NAMES, Ball, Grid, Key, MiniGridEnv
+from gym_minigrid.minigrid import (
+    COLOR_NAMES,
+    Ball,
+    Grid,
+    Key,
+    MiniGridEnv,
+    MissionSpace,
+)
 
 
 class FetchEnv(MiniGridEnv):
@@ -9,9 +16,26 @@ class FetchEnv(MiniGridEnv):
 
     def __init__(self, size=8, numObjs=3, **kwargs):
         self.numObjs = numObjs
+        self.obj_types = ["key", "ball"]
 
+        MISSION_SYNTAX = [
+            "get a",
+            "go get a",
+            "fetch a",
+            "go fetch a",
+            "you must fetch a",
+        ]
+        self.size = size
+        mission_space = MissionSpace(
+            mission_func=lambda syntax, color, type: "{} {} {}".format(
+                syntax, color, type
+            ),
+            ordered_placeholders=[MISSION_SYNTAX, COLOR_NAMES, self.obj_types],
+        )
         super().__init__(
-            grid_size=size,
+            mission_space=mission_space,
+            width=size,
+            height=size,
             max_steps=5 * size**2,
             # Set this to True for maximum speed
             see_through_walls=True,
@@ -27,13 +51,11 @@ class FetchEnv(MiniGridEnv):
         self.grid.vert_wall(0, 0)
         self.grid.vert_wall(width - 1, 0)
 
-        types = ["key", "ball"]
-
         objs = []
 
         # For each object to be generated
         while len(objs) < self.numObjs:
-            objType = self._rand_elem(types)
+            objType = self._rand_elem(self.obj_types)
             objColor = self._rand_elem(COLOR_NAMES)
 
             if objType == "key":

--- a/gym_minigrid/envs/fetch.py
+++ b/gym_minigrid/envs/fetch.py
@@ -27,9 +27,7 @@ class FetchEnv(MiniGridEnv):
         ]
         self.size = size
         mission_space = MissionSpace(
-            mission_func=lambda syntax, color, type: "{} {} {}".format(
-                syntax, color, type
-            ),
+            mission_func=lambda syntax, color, type: f"{syntax} {color} {type}",
             ordered_placeholders=[MISSION_SYNTAX, COLOR_NAMES, self.obj_types],
         )
         super().__init__(

--- a/gym_minigrid/envs/fourrooms.py
+++ b/gym_minigrid/envs/fourrooms.py
@@ -1,4 +1,4 @@
-from gym_minigrid.minigrid import Goal, Grid, MiniGridEnv
+from gym_minigrid.minigrid import Goal, Grid, MiniGridEnv, MissionSpace
 
 
 class FourRoomsEnv(MiniGridEnv):
@@ -10,7 +10,17 @@ class FourRoomsEnv(MiniGridEnv):
     def __init__(self, agent_pos=None, goal_pos=None, **kwargs):
         self._agent_default_pos = agent_pos
         self._goal_default_pos = goal_pos
-        super().__init__(grid_size=19, max_steps=100, **kwargs)
+
+        self.size = 19
+        mission_space = MissionSpace(mission_func=lambda: "reach the goal")
+
+        super().__init__(
+            mission_space=mission_space,
+            width=self.size,
+            height=self.size,
+            max_steps=100,
+            **kwargs
+        )
 
     def _gen_grid(self, width, height):
         # Create the grid
@@ -61,8 +71,6 @@ class FourRoomsEnv(MiniGridEnv):
             goal.init_pos, goal.cur_pos = self._goal_default_pos
         else:
             self.place_obj(Goal())
-
-        self.mission = "reach the goal"
 
     def step(self, action):
         obs, reward, done, info = MiniGridEnv.step(self, action)

--- a/gym_minigrid/envs/gotodoor.py
+++ b/gym_minigrid/envs/gotodoor.py
@@ -1,4 +1,4 @@
-from gym_minigrid.minigrid import COLOR_NAMES, Door, Grid, MiniGridEnv
+from gym_minigrid.minigrid import COLOR_NAMES, Door, Grid, MiniGridEnv, MissionSpace
 
 
 class GoToDoorEnv(MiniGridEnv):
@@ -9,13 +9,19 @@ class GoToDoorEnv(MiniGridEnv):
 
     def __init__(self, size=5, **kwargs):
         assert size >= 5
-
+        self.size = size
+        mission_space = MissionSpace(
+            mission_func=lambda color: f"go to the {color} door",
+            ordered_placeholders=[COLOR_NAMES],
+        )
         super().__init__(
-            grid_size=size,
+            mission_space=mission_space,
+            width=size,
+            height=size,
             max_steps=5 * size**2,
             # Set this to True for maximum speed
             see_through_walls=True,
-            **kwargs
+            **kwargs,
         )
 
     def _gen_grid(self, width, height):

--- a/gym_minigrid/envs/gotoobject.py
+++ b/gym_minigrid/envs/gotoobject.py
@@ -1,4 +1,12 @@
-from gym_minigrid.minigrid import COLOR_NAMES, Ball, Box, Grid, Key, MiniGridEnv
+from gym_minigrid.minigrid import (
+    COLOR_NAMES,
+    Ball,
+    Box,
+    Grid,
+    Key,
+    MiniGridEnv,
+    MissionSpace,
+)
 
 
 class GoToObjectEnv(MiniGridEnv):
@@ -9,9 +17,18 @@ class GoToObjectEnv(MiniGridEnv):
 
     def __init__(self, size=6, numObjs=2, **kwargs):
         self.numObjs = numObjs
+        self.size = size
+        # Types of objects to be generated
+        self.obj_types = ["key", "ball", "box"]
 
+        mission_space = MissionSpace(
+            mission_func=lambda color, type: f"go to the {color} {type}",
+            ordered_placeholders=[COLOR_NAMES, self.obj_types],
+        )
         super().__init__(
-            grid_size=size,
+            mission_space=mission_space,
+            width=size,
+            height=size,
             max_steps=5 * size**2,
             # Set this to True for maximum speed
             see_through_walls=True,

--- a/gym_minigrid/envs/keycorridor.py
+++ b/gym_minigrid/envs/keycorridor.py
@@ -1,3 +1,4 @@
+from gym_minigrid.minigrid import COLOR_NAMES, MissionSpace
 from gym_minigrid.roomgrid import RoomGrid
 
 
@@ -9,8 +10,12 @@ class KeyCorridorEnv(RoomGrid):
 
     def __init__(self, num_rows=3, obj_type="ball", room_size=6, **kwargs):
         self.obj_type = obj_type
-
+        mission_space = MissionSpace(
+            mission_func=lambda color: f"pick up the {color} {obj_type}",
+            ordered_placeholders=[COLOR_NAMES],
+        )
         super().__init__(
+            mission_space=mission_space,
             room_size=room_size,
             num_rows=num_rows,
             max_steps=30 * room_size**2,

--- a/gym_minigrid/envs/lavagap.py
+++ b/gym_minigrid/envs/lavagap.py
@@ -12,15 +12,15 @@ class LavaGapEnv(MiniGridEnv):
     def __init__(self, size, obstacle_type=Lava, **kwargs):
         self.obstacle_type = obstacle_type
         self.size = size
-        mission_space = (
-            MissionSpace(
+
+        if obstacle_type == Lava:
+            mission_space = MissionSpace(
                 mission_func=lambda: "avoid the lava and get to the green goal square"
             )
-            if self.obstacle_type == Lava
-            else MissionSpace(
+        else:
+            mission_space = MissionSpace(
                 mission_func=lambda: "find the opening and get to the green goal square"
             )
-        )
 
         super().__init__(
             mission_space=mission_space,

--- a/gym_minigrid/envs/lavagap.py
+++ b/gym_minigrid/envs/lavagap.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from gym_minigrid.minigrid import Goal, Grid, Lava, MiniGridEnv
+from gym_minigrid.minigrid import Goal, Grid, Lava, MiniGridEnv, MissionSpace
 
 
 class LavaGapEnv(MiniGridEnv):
@@ -11,12 +11,24 @@ class LavaGapEnv(MiniGridEnv):
 
     def __init__(self, size, obstacle_type=Lava, **kwargs):
         self.obstacle_type = obstacle_type
+        self.size = size
+        mission_space = (
+            MissionSpace(
+                mission_func=lambda: "avoid the lava and get to the green goal square"
+            )
+            if self.obstacle_type == Lava
+            else MissionSpace(
+                mission_func=lambda: "find the opening and get to the green goal square"
+            )
+        )
+
         super().__init__(
-            grid_size=size,
+            mission_space=mission_space,
+            width=size,
+            height=size,
             max_steps=4 * size * size,
             # Set this to True for maximum speed
             see_through_walls=False,
-            **kwargs
         )
 
     def _gen_grid(self, width, height):

--- a/gym_minigrid/envs/lockedroom.py
+++ b/gym_minigrid/envs/lockedroom.py
@@ -33,11 +33,7 @@ class LockedRoomEnv(MiniGridEnv):
     def __init__(self, size=19, **kwargs):
         self.size = size
         mission_space = MissionSpace(
-            mission_func=lambda lockedroom_color, keyroom_color, door_color: "get the {} key from the {} room, unlock the {} door and go to the goal".format(
-                lockedroom_color,
-                keyroom_color,
-                lockedroom_color,
-            ),
+            mission_func=lambda lockedroom_color, keyroom_color, door_color: f"get the {lockedroom_color} key from the {keyroom_color} room, unlock the {door_color} door and go to the goal",
             ordered_placeholders=[COLOR_NAMES] * 3,
         )
         super().__init__(
@@ -45,7 +41,7 @@ class LockedRoomEnv(MiniGridEnv):
             width=size,
             height=size,
             max_steps=10 * size,
-            **kwargs
+            **kwargs,
         )
 
     def _gen_grid(self, width, height):

--- a/gym_minigrid/envs/lockedroom.py
+++ b/gym_minigrid/envs/lockedroom.py
@@ -1,4 +1,13 @@
-from gym_minigrid.minigrid import COLOR_NAMES, Door, Goal, Grid, Key, MiniGridEnv, Wall
+from gym_minigrid.minigrid import (
+    COLOR_NAMES,
+    Door,
+    Goal,
+    Grid,
+    Key,
+    MiniGridEnv,
+    MissionSpace,
+    Wall,
+)
 
 
 class LockedRoom:
@@ -22,7 +31,22 @@ class LockedRoomEnv(MiniGridEnv):
     """
 
     def __init__(self, size=19, **kwargs):
-        super().__init__(grid_size=size, max_steps=10 * size, **kwargs)
+        self.size = size
+        mission_space = MissionSpace(
+            mission_func=lambda lockedroom_color, keyroom_color, door_color: "get the {} key from the {} room, unlock the {} door and go to the goal".format(
+                lockedroom_color,
+                keyroom_color,
+                lockedroom_color,
+            ),
+            ordered_placeholders=[COLOR_NAMES] * 3,
+        )
+        super().__init__(
+            mission_space=mission_space,
+            width=size,
+            height=size,
+            max_steps=10 * size,
+            **kwargs
+        )
 
     def _gen_grid(self, width, height):
         # Create the grid

--- a/gym_minigrid/envs/memory.py
+++ b/gym_minigrid/envs/memory.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from gym_minigrid.minigrid import Ball, Grid, Key, MiniGridEnv, Wall
+from gym_minigrid.minigrid import Ball, Grid, Key, MiniGridEnv, MissionSpace, Wall
 
 
 class MemoryEnv(MiniGridEnv):
@@ -14,9 +14,15 @@ class MemoryEnv(MiniGridEnv):
     """
 
     def __init__(self, size=8, random_length=False, **kwargs):
+        self.size = size
         self.random_length = random_length
+        mission_space = MissionSpace(
+            mission_func=lambda: "go to the matching object at the end of the hallway"
+        )
         super().__init__(
-            grid_size=size,
+            mission_space=mission_space,
+            width=size,
+            height=size,
             max_steps=5 * size**2,
             # Set this to True for maximum speed
             see_through_walls=False,

--- a/gym_minigrid/envs/multiroom.py
+++ b/gym_minigrid/envs/multiroom.py
@@ -1,4 +1,12 @@
-from gym_minigrid.minigrid import COLOR_NAMES, Door, Goal, Grid, MiniGridEnv, Wall
+from gym_minigrid.minigrid import (
+    COLOR_NAMES,
+    Door,
+    Goal,
+    Grid,
+    MiniGridEnv,
+    MissionSpace,
+    Wall,
+)
 
 
 class MultiRoom:
@@ -25,7 +33,18 @@ class MultiRoomEnv(MiniGridEnv):
 
         self.rooms = []
 
-        super().__init__(grid_size=25, max_steps=self.maxNumRooms * 20, **kwargs)
+        mission_space = MissionSpace(
+            mission_func=lambda: "traverse the rooms to get to the goal"
+        )
+
+        self.size = 25
+
+        super().__init__(
+            mission_space=mission_space,
+            width=self.size,
+            height=self.size,
+            max_steps=self.maxNumRooms * 20,
+        )
 
     def _gen_grid(self, width, height):
         roomList = []

--- a/gym_minigrid/envs/obstructedmaze.py
+++ b/gym_minigrid/envs/obstructedmaze.py
@@ -1,4 +1,4 @@
-from gym_minigrid.minigrid import COLOR_NAMES, DIR_TO_VEC, Ball, Box, Key
+from gym_minigrid.minigrid import COLOR_NAMES, DIR_TO_VEC, Ball, Box, Key, MissionSpace
 from gym_minigrid.roomgrid import RoomGrid
 
 
@@ -12,12 +12,16 @@ class ObstructedMazeEnv(RoomGrid):
         room_size = 6
         max_steps = 4 * num_rooms_visited * room_size**2
 
+        mission_space = MissionSpace(
+            mission_func=lambda: f"pick up the {COLOR_NAMES[0]} ball",
+        )
         super().__init__(
+            mission_space=mission_space,
             room_size=room_size,
             num_rows=num_rows,
             num_cols=num_cols,
             max_steps=max_steps,
-            **kwargs
+            **kwargs,
         )
 
     def _gen_grid(self, width, height):
@@ -121,7 +125,7 @@ class ObstructedMaze_Full(ObstructedMazeEnv):
         blocked=True,
         num_quarters=4,
         num_rooms_visited=25,
-        **kwargs
+        **kwargs,
     ):
         self.agent_room = agent_room
         self.key_in_box = key_in_box
@@ -155,7 +159,7 @@ class ObstructedMaze_Full(ObstructedMazeEnv):
                     door_idx=(i + k) % 4,
                     color=self.door_colors[(i + k) % len(self.door_colors)],
                     key_in_box=self.key_in_box,
-                    blocked=self.blocked
+                    blocked=self.blocked,
                 )
 
         corners = [(2, 0), (2, 2), (0, 2), (0, 0)][: self.num_quarters]

--- a/gym_minigrid/envs/playground.py
+++ b/gym_minigrid/envs/playground.py
@@ -1,4 +1,13 @@
-from gym_minigrid.minigrid import COLOR_NAMES, Ball, Box, Door, Grid, Key, MiniGridEnv
+from gym_minigrid.minigrid import (
+    COLOR_NAMES,
+    Ball,
+    Box,
+    Door,
+    Grid,
+    Key,
+    MiniGridEnv,
+    MissionSpace,
+)
 
 
 class PlaygroundEnv(MiniGridEnv):
@@ -8,7 +17,15 @@ class PlaygroundEnv(MiniGridEnv):
     """
 
     def __init__(self, **kwargs):
-        super().__init__(grid_size=19, max_steps=100, **kwargs)
+        mission_space = MissionSpace(mission_func=lambda: "")
+        self.size = 19
+        super().__init__(
+            mission_space=mission_space,
+            width=self.size,
+            height=self.size,
+            max_steps=100,
+            **kwargs
+        )
 
     def _gen_grid(self, width, height):
         # Create the grid

--- a/gym_minigrid/envs/putnear.py
+++ b/gym_minigrid/envs/putnear.py
@@ -20,12 +20,7 @@ class PutNearEnv(MiniGridEnv):
         self.numObjs = numObjs
         self.obj_types = ["key", "ball", "box"]
         mission_space = MissionSpace(
-            mission_func=lambda move_color, move_type, target_color, target_type: "put the {} {} near the {} {}".format(
-                move_color,
-                move_type,
-                target_color,
-                target_type,
-            ),
+            mission_func=lambda move_color, move_type, target_color, target_type: f"put the {move_color} {move_type} near the {target_color} {target_type}",
             ordered_placeholders=[
                 COLOR_NAMES,
                 self.obj_types,

--- a/gym_minigrid/envs/putnear.py
+++ b/gym_minigrid/envs/putnear.py
@@ -1,4 +1,12 @@
-from gym_minigrid.minigrid import COLOR_NAMES, Ball, Box, Grid, Key, MiniGridEnv
+from gym_minigrid.minigrid import (
+    COLOR_NAMES,
+    Ball,
+    Box,
+    Grid,
+    Key,
+    MiniGridEnv,
+    MissionSpace,
+)
 
 
 class PutNearEnv(MiniGridEnv):
@@ -8,14 +16,30 @@ class PutNearEnv(MiniGridEnv):
     """
 
     def __init__(self, size=6, numObjs=2, **kwargs):
+        self.size = size
         self.numObjs = numObjs
-
+        self.obj_types = ["key", "ball", "box"]
+        mission_space = MissionSpace(
+            mission_func=lambda move_color, move_type, target_color, target_type: "put the {} {} near the {} {}".format(
+                move_color,
+                move_type,
+                target_color,
+                target_type,
+            ),
+            ordered_placeholders=[
+                COLOR_NAMES,
+                self.obj_types,
+                COLOR_NAMES,
+                self.obj_types,
+            ],
+        )
         super().__init__(
-            grid_size=size,
+            mission_space=mission_space,
+            width=size,
+            height=size,
             max_steps=5 * size,
             # Set this to True for maximum speed
             see_through_walls=True,
-            **kwargs
         )
 
     def _gen_grid(self, width, height):

--- a/gym_minigrid/envs/redbluedoors.py
+++ b/gym_minigrid/envs/redbluedoors.py
@@ -1,4 +1,4 @@
-from gym_minigrid.minigrid import Door, Grid, MiniGridEnv
+from gym_minigrid.minigrid import Door, Grid, MiniGridEnv, MissionSpace
 
 
 class RedBlueDoorEnv(MiniGridEnv):
@@ -10,9 +10,15 @@ class RedBlueDoorEnv(MiniGridEnv):
 
     def __init__(self, size=8, **kwargs):
         self.size = size
-
+        mission_space = MissionSpace(
+            mission_func=lambda: "open the red door then the blue door"
+        )
         super().__init__(
-            width=2 * size, height=size, max_steps=20 * size * size, **kwargs
+            mission_space=mission_space,
+            width=2 * size,
+            height=size,
+            max_steps=20 * size * size,
+            **kwargs
         )
 
     def _gen_grid(self, width, height):

--- a/gym_minigrid/envs/unlock.py
+++ b/gym_minigrid/envs/unlock.py
@@ -1,3 +1,4 @@
+from gym_minigrid.minigrid import MissionSpace
 from gym_minigrid.roomgrid import RoomGrid
 
 
@@ -8,7 +9,9 @@ class UnlockEnv(RoomGrid):
 
     def __init__(self, **kwargs):
         room_size = 6
+        mission_space = MissionSpace(mission_func=lambda: "open the door")
         super().__init__(
+            mission_space=mission_space,
             num_rows=1,
             num_cols=2,
             room_size=room_size,

--- a/gym_minigrid/envs/unlockpickup.py
+++ b/gym_minigrid/envs/unlockpickup.py
@@ -1,3 +1,4 @@
+from gym_minigrid.minigrid import COLOR_NAMES, MissionSpace
 from gym_minigrid.roomgrid import RoomGrid
 
 
@@ -8,7 +9,12 @@ class UnlockPickupEnv(RoomGrid):
 
     def __init__(self, **kwargs):
         room_size = 6
+        mission_space = MissionSpace(
+            mission_func=lambda color: f"pick up the {color} box",
+            ordered_placeholders=[COLOR_NAMES],
+        )
         super().__init__(
+            mission_space=mission_space,
             num_rows=1,
             num_cols=2,
             room_size=room_size,

--- a/gym_minigrid/manual_control.py
+++ b/gym_minigrid/manual_control.py
@@ -93,7 +93,7 @@ parser.add_argument(
 
 args = parser.parse_args()
 
-env = gym.make(args.env, render_mode="rgb_array")
+env = gym.make(args.env)
 
 if args.agent_view:
     env = RGBImgPartialObsWrapper(env)

--- a/gym_minigrid/minigrid.py
+++ b/gym_minigrid/minigrid.py
@@ -161,6 +161,7 @@ class MissionSpace(spaces.Space[str]):
                 for placeholder in placeholder_list:
                     if placeholder in x:
                         check_placeholder_list.append(placeholder)
+
             # Remove duplicates from the list
             check_placeholder_list = list(set(check_placeholder_list))
 
@@ -213,6 +214,14 @@ class MissionSpace(spaces.Space[str]):
                 placeholder[2] for placeholder in ordered_placeholder_list
             ]
 
+            # Check that the identified final placeholders are in the same order as the original placeholders.
+            for orered_placeholder, final_placeholder in zip(
+                self.ordered_placeholders, final_placeholders
+            ):
+                if final_placeholder in orered_placeholder:
+                    continue
+                else:
+                    return False
             try:
                 mission_string_with_placeholders = self.mission_func(
                     *final_placeholders

--- a/gym_minigrid/minigrid.py
+++ b/gym_minigrid/minigrid.py
@@ -166,10 +166,10 @@ class MissionSpace(spaces.Space[str]):
                         check_placeholder_list.append(placeholder)
             # Remove duplicates from the list
             check_placeholder_list = list(set(check_placeholder_list))
+
             start_id_placeholder = []
             end_id_placeholder = []
-
-            # Get the starting and ending id of the founded placeholders with possible duplicates
+            # Get the starting and ending id of the identified placeholders with possible duplicates
             new_check_placeholder_list = []
             for placeholder in check_placeholder_list:
                 new_start_id_placeholder = [

--- a/gym_minigrid/minigrid.py
+++ b/gym_minigrid/minigrid.py
@@ -87,11 +87,11 @@ class MissionSpace(spaces.Space[str]):
     r"""A space representing a mission for the Gym-Minigrid environments.
     The space allows generating random mission strings constructed with an input placeholder list.
     Example Usage::
-        >>> observation_space = MissionSpace(mission_func=lambda color: "Get the {} ball.".format(color),
+        >>> observation_space = MissionSpace(mission_func=lambda color: f"Get the {color} ball.",
                                                 ordered_placeholders=[["green", "blue"]])
         >>> observation_space.sample()
             "Get the green ball."
-        >>> observation_space = MissionSpace(mission_func=lambda color: "Get the ball.".,
+        >>> observation_space = MissionSpace(mission_func=lambda : "Get the ball.".,
                                                 ordered_placeholders=None)
         >>> observation_space.sample()
             "Get the ball."
@@ -114,9 +114,7 @@ class MissionSpace(spaces.Space[str]):
         if ordered_placeholders is not None:
             assert (
                 len(ordered_placeholders) == mission_func.__code__.co_argcount
-            ), "The number of placeholders {} is different from the number of parameters in the mission function {}.".format(
-                len(ordered_placeholders), mission_func.__code__.co_argcount
-            )
+            ), f"The number of placeholders {len(ordered_placeholders)} is different from the number of parameters in the mission function {mission_func.__code__.co_argcount}."
             for placeholder_list in ordered_placeholders:
                 assert check_if_no_duplicate(
                     placeholder_list
@@ -124,9 +122,7 @@ class MissionSpace(spaces.Space[str]):
         else:
             assert (
                 mission_func.__code__.co_argcount == 0
-            ), "If the ordered placeholders are {}, the mission function shouldn't have any parameters.".format(
-                ordered_placeholders
-            )
+            ), f"If the ordered placeholders are {ordered_placeholders}, the mission function shouldn't have any parameters."
 
         self.ordered_placeholders = ordered_placeholders
         self.mission_func = mission_func
@@ -460,9 +456,7 @@ class Door(WorldObj):
             state = 1
         else:
             raise ValueError(
-                "There is no possible state encoding for the state:\n -Door Open: {}\n -Door Closed: {}\n -Door Locked: {}".format(
-                    self.is_open, not self.is_open, self.is_locked
-                )
+                f"There is no possible state encoding for the state:\n -Door Open: {self.is_open}\n -Door Closed: {not self.is_open}\n -Door Locked: {self.is_locked}"
             )
 
         return (OBJECT_TO_IDX[self.type], COLOR_TO_IDX[self.color], state)

--- a/gym_minigrid/minigrid.py
+++ b/gym_minigrid/minigrid.py
@@ -2,14 +2,12 @@ import hashlib
 import math
 from abc import abstractmethod
 from enum import IntEnum
-from functools import partial
 from typing import Any, Callable, Optional, Union
 
 import gym
 import numpy as np
 from gym import spaces
 from gym.utils import seeding
-from gym.utils.renderer import Renderer
 
 # Size in pixels of a tile in the full-scale human view
 from gym_minigrid.rendering import (
@@ -861,7 +859,6 @@ class MiniGridEnv(gym.Env):
         max_steps: int = 100,
         see_through_walls: bool = False,
         agent_view_size: int = 7,
-        render_mode: str = None,
         highlight: bool = True,
         tile_size: int = TILE_PIXELS,
         **kwargs,
@@ -902,15 +899,6 @@ class MiniGridEnv(gym.Env):
                 "mission": mission_space,
             }
         )
-
-        # render mode
-        self.render_mode = render_mode
-        render_frame = partial(
-            self._render,
-            highlight=highlight,
-            tile_size=tile_size,
-        )
-        self.renderer = Renderer(self.render_mode, render_frame)
 
         # Range of possible rewards
         self.reward_range = (0, 1)
@@ -956,8 +944,6 @@ class MiniGridEnv(gym.Env):
         # Return first observation
         obs = self.gen_obs()
 
-        self.renderer.reset()
-        self.renderer.render_step()
         if not return_info:
             return obs
         else:
@@ -1372,7 +1358,6 @@ class MiniGridEnv(gym.Env):
 
         obs = self.gen_obs()
 
-        self.renderer.render_step()
         return obs, reward, done, {}
 
     def gen_obs_grid(self, agent_view_size=None):
@@ -1451,7 +1436,7 @@ class MiniGridEnv(gym.Env):
 
         return img
 
-    def _render(self, mode="human", highlight=True, tile_size=TILE_PIXELS):
+    def render(self, mode="human", highlight=True, tile_size=TILE_PIXELS):
         assert mode in self.metadata["render_modes"]
         """
         Render the whole-grid human view
@@ -1507,16 +1492,6 @@ class MiniGridEnv(gym.Env):
             self.window.show_img(img)
         else:
             return img
-
-    def render(self, mode="human", close=False, highlight=True, tile_size=TILE_PIXELS):
-        if close:
-            raise Exception(
-                "Please close the rendering window using env.close(). Closing the rendering window with the render method is no longer allowed."
-            )
-        if self.render_mode is not None:
-            return self.renderer.get_renders()
-        else:
-            return self._render(mode, highlight=highlight, tile_size=tile_size)
 
     def close(self):
         if self.window:

--- a/gym_minigrid/minigrid.py
+++ b/gym_minigrid/minigrid.py
@@ -244,17 +244,12 @@ class MissionSpace(spaces.Space[str]):
             # Check that place holder lists are the same
             if self.ordered_placeholders is not None:
                 # Check length
-                if len(self.order_placeholder) == len(other.order_placeholder):
-
-                    # Placeholder list are ordered in placing order in the mission string
-                    for placeholder, other_placeholder in zip(
-                        self.order_placeholder, other.order_placeholder
-                    ):
-                        if set(placeholder) == set(other_placeholder):
-                            continue
-                        else:
-                            return False
-
+                if (len(self.order_placeholder) == len(other.order_placeholder)) and (
+                    all(
+                        set(i) == set(j)
+                        for i, j in zip(self.order_placeholder, other.order_placeholder)
+                    )
+                ):
                     # Check mission string is the same with dummy space placeholders
                     test_placeholders = [""] * len(self.order_placeholder)
                     mission = self.mission_func(*test_placeholders)

--- a/gym_minigrid/minigrid.py
+++ b/gym_minigrid/minigrid.py
@@ -78,12 +78,9 @@ DIR_TO_VEC = [
 ]
 
 
-def check_if_duplicate(duplicate_list: list) -> bool:
+def check_if_no_duplicate(duplicate_list: list) -> bool:
     """Check if given list contains any duplicates"""
-    for element in duplicate_list:
-        if duplicate_list.count(element) > 1:
-            return True
-    return False
+    return len(set(duplicate_list)) == len(duplicate_list)
 
 
 class MissionSpace(spaces.Space[str]):
@@ -121,7 +118,7 @@ class MissionSpace(spaces.Space[str]):
                 len(ordered_placeholders), mission_func.__code__.co_argcount
             )
             for placeholder_list in ordered_placeholders:
-                assert not check_if_duplicate(
+                assert check_if_no_duplicate(
                     placeholder_list
                 ), "Make sure that the placeholders don't have any duplicate values."
         else:
@@ -237,35 +234,39 @@ class MissionSpace(spaces.Space[str]):
 
     def __eq__(self, other) -> bool:
         """Check whether ``other`` is equivalent to this instance."""
-        if not isinstance(other, MissionSpace):
-            return False
+        if isinstance(other, MissionSpace):
 
-        # Check that place holder lists are the same
-        if self.ordered_placeholders is not None:
-            # Check length
-            if len(self.order_placeholder) != len(other.order_placeholder):
-                return False
+            # Check that place holder lists are the same
+            if self.ordered_placeholders is not None:
+                # Check length
+                if len(self.order_placeholder) == len(other.order_placeholder):
 
-            # Placeholder list are ordered in placing order in the mission string
-            for placeholder, other_placeholder in zip(
-                self.order_placeholder, other.order_placeholder
-            ):
-                if set(placeholder) != set(other_placeholder):
-                    return False
+                    # Placeholder list are ordered in placing order in the mission string
+                    for placeholder, other_placeholder in zip(
+                        self.order_placeholder, other.order_placeholder
+                    ):
+                        if set(placeholder) == set(other_placeholder):
+                            continue
+                        else:
+                            return False
 
-            # Check mission string is the same with dummy space placeholders
-            test_placeholders = [""] * len(self.order_placeholder)
-            mission = self.mission_func(*test_placeholders)
-            other_mission = other.mission_func(*test_placeholders)
-            return mission == other_mission
-        else:
-            if other.ordered_placeholders is not None:
-                return False
+                    # Check mission string is the same with dummy space placeholders
+                    test_placeholders = [""] * len(self.order_placeholder)
+                    mission = self.mission_func(*test_placeholders)
+                    other_mission = other.mission_func(*test_placeholders)
+                    return mission == other_mission
+            else:
 
-            # Check mission string is the same
-            mission = self.mission_func()
-            other_mission = other.mission_func()
-            return mission == other_mission
+                # Check that other is also None
+                if other.ordered_placeholders is None:
+
+                    # Check mission string is the same
+                    mission = self.mission_func()
+                    other_mission = other.mission_func()
+                    return mission == other_mission
+
+        # If none of the statements above return then False
+        return False
 
 
 class WorldObj:

--- a/gym_minigrid/minigrid.py
+++ b/gym_minigrid/minigrid.py
@@ -1,13 +1,14 @@
 import hashlib
 import math
-import string
 from abc import abstractmethod
 from enum import IntEnum
 from functools import partial
+from typing import Any, Callable, Optional, Union
 
 import gym
 import numpy as np
 from gym import spaces
+from gym.utils import seeding
 from gym.utils.renderer import Renderer
 
 # Size in pixels of a tile in the full-scale human view
@@ -77,6 +78,196 @@ DIR_TO_VEC = [
     # Up (negative Y)
     np.array((0, -1)),
 ]
+
+
+def check_if_duplicate(duplicate_list: list) -> bool:
+    """Check if given list contains any duplicates"""
+    for element in duplicate_list:
+        if duplicate_list.count(element) > 1:
+            return True
+    return False
+
+
+class MissionSpace(spaces.Space[str]):
+    r"""A space representing a mission for the Gym-Minigrid environments.
+    The space allows generating random mission strings constructed with an input placeholder list.
+    Example Usage::
+        >>> observation_space = MissionSpace(mission_func=lambda color: "Get the {} ball.".format(color),
+                                                ordered_placeholders=[["green", "blue"]])
+        >>> observation_space.sample()
+            "Get the green ball."
+        >>> observation_space = MissionSpace(mission_func=lambda color: "Get the ball.".,
+                                                ordered_placeholders=None)
+        >>> observation_space.sample()
+            "Get the ball."
+    """
+
+    def __init__(
+        self,
+        mission_func: Callable[..., str],
+        ordered_placeholders: Optional["list[list[str]]"] = None,
+        seed: Optional[Union[int, seeding.RandomNumberGenerator]] = None,
+    ):
+        r"""Constructor of :class:`MissionSpace` space.
+
+        Args:
+            mission_func (lambda _placeholders(str): _mission(str)): Function that generates a mission string from random placeholders.
+            ordered_placeholders (Optional["list[list[str]]"]): List of lists of placeholders ordered in placing order in the mission function mission_func.
+            seed: seed: The seed for sampling from the space.
+        """
+        # Check that the ordered placeholders and mission function are well defined.
+        if ordered_placeholders is not None:
+            assert (
+                len(ordered_placeholders) == mission_func.__code__.co_argcount
+            ), "The number of placeholders {} is different from the number of parameters in the mission function {}.".format(
+                len(ordered_placeholders), mission_func.__code__.co_argcount
+            )
+            for placeholder_list in ordered_placeholders:
+                assert not check_if_duplicate(
+                    placeholder_list
+                ), "Make sure that the placeholders don't have any duplicate values."
+        else:
+            assert (
+                mission_func.__code__.co_argcount == 0
+            ), "If the ordered placeholders are {}, the mission function shouldn't have any parameters.".format(
+                ordered_placeholders
+            )
+
+        self.ordered_placeholders = ordered_placeholders
+        self.mission_func = mission_func
+
+        super().__init__(dtype=str, seed=seed)
+
+        # Check that mission_func returns a string
+        sampled_mission = self.sample()
+        assert isinstance(
+            sampled_mission, str
+        ), f"mission_func must return type str not {type(sampled_mission)}"
+
+    def sample(self) -> str:
+        """Sample a random mission string."""
+        if self.ordered_placeholders is not None:
+            placeholders = []
+            for rand_var_list in self.ordered_placeholders:
+                idx = self.np_random.integers(0, len(rand_var_list))
+
+                placeholders.append(rand_var_list[idx])
+
+            return self.mission_func(*placeholders)
+        else:
+            return self.mission_func()
+
+    def contains(self, x: Any) -> bool:
+        """Return boolean specifying if x is a valid member of this space."""
+        # Store a list of all the placeholders from self.ordered_placeholders that appear in x
+        if self.ordered_placeholders is not None:
+            check_placeholder_list = []
+            for placeholder_list in self.ordered_placeholders:
+                for placeholder in placeholder_list:
+                    if placeholder in x:
+                        check_placeholder_list.append(placeholder)
+            # Remove duplicates from the list
+            check_placeholder_list = list(set(check_placeholder_list))
+            start_id_placeholder = []
+            end_id_placeholder = []
+
+            # Get the starting and ending id of the founded placeholders with possible duplicates
+            new_check_placeholder_list = []
+            for placeholder in check_placeholder_list:
+                new_start_id_placeholder = [
+                    i for i in range(len(x)) if x.startswith(placeholder, i)
+                ]
+                new_check_placeholder_list += [placeholder] * len(
+                    new_start_id_placeholder
+                )
+                end_id_placeholder += [
+                    start_id + len(placeholder) - 1
+                    for start_id in new_start_id_placeholder
+                ]
+                start_id_placeholder += new_start_id_placeholder
+
+            # Order by starting id the placeholders
+            ordered_placeholder_list = sorted(
+                zip(
+                    start_id_placeholder, end_id_placeholder, new_check_placeholder_list
+                )
+            )
+
+            # Check for repeated placeholders contained in each other
+            remove_placeholder_id = []
+            for i, placeholder_1 in enumerate(ordered_placeholder_list):
+                starting_id = i + 1
+                for j, placeholder_2 in enumerate(
+                    ordered_placeholder_list[starting_id:]
+                ):
+                    # Check if place holder ids overlap and keep the longest
+                    if max(placeholder_1[0], placeholder_2[0]) < min(
+                        placeholder_1[1], placeholder_2[1]
+                    ):
+                        remove_placeholder = min(
+                            placeholder_1[2], placeholder_2[2], key=len
+                        )
+                        if remove_placeholder == placeholder_1[2]:
+                            remove_placeholder_id.append(i)
+                        else:
+                            remove_placeholder_id.append(i + j + 1)
+            for id in remove_placeholder_id:
+                del ordered_placeholder_list[id]
+
+            final_placeholders = [
+                placeholder[2] for placeholder in ordered_placeholder_list
+            ]
+
+            try:
+                mission_string_with_placeholders = self.mission_func(
+                    *final_placeholders
+                )
+            except Exception as e:
+                print(
+                    f"{x} is not contained in MissionSpace due to the following exception: {e}"
+                )
+                return False
+
+            return bool(mission_string_with_placeholders == x)
+
+        else:
+            return bool(self.mission_func() == x)
+
+    def __repr__(self) -> str:
+        """Gives a string representation of this space."""
+        return f"MissionSpace({self.mission_func}, {self.ordered_placeholders})"
+
+    def __eq__(self, other) -> bool:
+        """Check whether ``other`` is equivalent to this instance."""
+        if not isinstance(other, MissionSpace):
+            return False
+
+        # Check that place holder lists are the same
+        if self.ordered_placeholders is not None:
+            # Check length
+            if len(self.order_placeholder) != len(other.order_placeholder):
+                return False
+
+            # Placeholder list are ordered in placing order in the mission string
+            for placeholder, other_placeholder in zip(
+                self.order_placeholder, other.order_placeholder
+            ):
+                if set(placeholder) != set(other_placeholder):
+                    return False
+
+            # Check mission string is the same with dummy space placeholders
+            test_placeholders = [""] * len(self.order_placeholder)
+            mission = self.mission_func(*test_placeholders)
+            other_mission = other.mission_func(*test_placeholders)
+            return mission == other_mission
+        else:
+            if other.ordered_placeholders is not None:
+                return False
+
+            # Check mission string is the same
+            mission = self.mission_func()
+            other_mission = other.mission_func()
+            return mission == other_mission
 
 
 class WorldObj:
@@ -663,6 +854,7 @@ class MiniGridEnv(gym.Env):
 
     def __init__(
         self,
+        mission_space: MissionSpace,
         grid_size: int = None,
         width: int = None,
         height: int = None,
@@ -672,8 +864,12 @@ class MiniGridEnv(gym.Env):
         render_mode: str = None,
         highlight: bool = True,
         tile_size: int = TILE_PIXELS,
-        **kwargs
+        **kwargs,
     ):
+
+        # Initialize mission
+        self.mission = mission_space.sample()
+
         # Can't set both grid_size and width/height
         if grid_size:
             assert width is None and height is None
@@ -693,7 +889,7 @@ class MiniGridEnv(gym.Env):
 
         # Observations are dictionaries containing an
         # encoding of the grid and a textual 'mission' string
-        self.observation_space = spaces.Box(
+        image_observation_space = spaces.Box(
             low=0,
             high=255,
             shape=(self.agent_view_size, self.agent_view_size, 3),
@@ -701,12 +897,9 @@ class MiniGridEnv(gym.Env):
         )
         self.observation_space = spaces.Dict(
             {
-                "image": self.observation_space,
+                "image": image_observation_space,
                 "direction": spaces.Discrete(4),
-                "mission": spaces.Text(
-                    max_length=200,
-                    charset=string.ascii_letters + string.digits + " .,!-",
-                ),
+                "mission": mission_space,
             }
         )
 

--- a/gym_minigrid/wrappers.py
+++ b/gym_minigrid/wrappers.py
@@ -181,9 +181,7 @@ class RGBImgObsWrapper(ObservationWrapper):
     def observation(self, obs):
         env = self.unwrapped
 
-        rgb_img = env._render(
-            mode="rgb_array", highlight=True, tile_size=self.tile_size
-        )
+        rgb_img = env.render(mode="rgb_array", highlight=True, tile_size=self.tile_size)
 
         return {**obs, "image": rgb_img}
 

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -101,11 +101,11 @@ def test_render_modes(spec):
 
     for mode in env.metadata.get("render_modes", []):
         if mode != "human":
-            new_env = spec.make(render_mode=mode)
+            new_env = spec.make()
 
             new_env.reset()
             new_env.step(new_env.action_space.sample())
-            new_env.render()
+            new_env.render(mode=mode)
 
 
 @pytest.mark.parametrize("env_id", ["MiniGrid-DoorKey-6x6-v0"])
@@ -192,7 +192,7 @@ def old_run_test(env_spec):
 
 @pytest.mark.parametrize("env_id", ["MiniGrid-Empty-8x8-v0"])
 def test_interactive_mode(env_id):
-    env = gym.make(env_id, render_mode="human")
+    env = gym.make(env_id)
     env.reset()
 
     for i in range(0, 100):


### PR DESCRIPTION
# Description
This PR makes `gym-minigrid` compatible with the latest `gym` versions: v25, v24, v23, and v22. (NOT v21)

The changes are:

- Revert to the old `rendering API` by removing `render_mode` argument and `Renderer` in the environment creation.
- Replacing the `Text` space of the observation mission string by a custom space `MissionSpace`. This space allows to sample random mission strings from a list of placeholder options.

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Screenshots
Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |


To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
