### PR TITLE
Add reset benchmark.py and fix render manual_control.py

### DIFF
--- a/gym_minigrid/benchmark.py
+++ b/gym_minigrid/benchmark.py
@@ -41,6 +41,7 @@ env = gym.make(args.env_name)
 env = RGBImgPartialObsWrapper(env)
 env = ImgObsWrapper(env)
 
+env.reset()
 # Benchmark rendering
 t0 = time.time()
 for i in range(args.num_frames):

--- a/gym_minigrid/manual_control.py
+++ b/gym_minigrid/manual_control.py
@@ -15,8 +15,7 @@ def redraw(img):
 
 
 def reset():
-    seed = None if args.seed == -1 else args.seed
-    obs = env.reset(seed=seed)
+    obs = env.reset()
 
     if hasattr(env, "mission"):
         print("Mission: %s" % env.mission)
@@ -92,7 +91,8 @@ parser.add_argument(
 
 args = parser.parse_args()
 
-env = gym.make(args.env)
+seed = None if args.seed == -1 else args.seed
+env = gym.make(args.env, seed=seed)
 
 if args.agent_view:
     env = RGBImgPartialObsWrapper(env)

--- a/gym_minigrid/manual_control.py
+++ b/gym_minigrid/manual_control.py
@@ -10,8 +10,7 @@ from gym_minigrid.wrappers import ImgObsWrapper, RGBImgPartialObsWrapper
 
 def redraw(img):
     if not args.agent_view:
-        img = env.render(tile_size=args.tile_size)
-
+        img = env.render(mode="rgb_array", tile_size=args.tile_size)
     window.show_img(img)
 
 


### PR DESCRIPTION
# Description

This PR:

- Fixes reset() before step() in `benchmark.py`
- Remove reset seeding in `manual_control.py`
- `"rgb_array"` rendering in `manual_control.py` when `redraw()` is called.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Screenshots
Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |


To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
