### PR TITLE
fix pytest warns

### DIFF
--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -1,3 +1,5 @@
+import warnings
+
 import gym
 import numpy as np
 import pytest
@@ -26,12 +28,11 @@ CHECK_ENV_IGNORE_WARNINGS = [
 def test_env(spec):
     # Capture warnings
     env = spec.make(disable_env_checker=True).unwrapped
-
+    warnings.simplefilter("always")
     # Test if env adheres to Gym API
-    with pytest.warns() as warnings:
+    with warnings.catch_warnings(record=True) as w:
         check_env(env)
-
-    for warning in warnings.list:
+    for warning in w:
         if warning.message.args[0] not in CHECK_ENV_IGNORE_WARNINGS:
             raise gym.error.Error(f"Unexpected warning: {warning.message}")
 


### PR DESCRIPTION
# Description
`pytest.warns(None)` is deprecated and `pytest.warns()` is expecting to have warnings during test, if not the test fails. As another option for recording test with possibly no-warnings use warnings.catch_warnings(record=True) as suggested in https://github.com/pytest-dev/pytest/issues/9002



## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Screenshots
Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |


To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
