### PR TITLE
Render API

### DIFF
--- a/gym_minigrid/manual_control.py
+++ b/gym_minigrid/manual_control.py
@@ -102,7 +102,6 @@ if __name__ == "__main__":
     env = gym.make(
         args.env,
         new_step_api=True,
-        render_mode="human",  # Note that we do not need to use "human", as Window handles human rendering.
         tile_size=args.tile_size,
     )
 

--- a/gym_minigrid/manual_control.py
+++ b/gym_minigrid/manual_control.py
@@ -17,7 +17,7 @@ def reset(env, window):
         print("Mission: %s" % env.mission)
         window.set_caption(env.mission)
 
-    img = env.get_render()
+    img = env.get_frame()
 
     redraw(window, img)
 

--- a/gym_minigrid/manual_control.py
+++ b/gym_minigrid/manual_control.py
@@ -111,7 +111,7 @@ if __name__ == "__main__":
 
     window = Window("gym_minigrid - " + args.env)
     window.reg_key_handler(lambda event: key_handler(env, window, event))
-    
+
     seed = None if args.seed == -1 else args.seed
     reset(env, window, seed)
 

--- a/gym_minigrid/manual_control.py
+++ b/gym_minigrid/manual_control.py
@@ -33,7 +33,7 @@ def step(env, window, action):
         print("truncated!")
         reset(env, window)
     else:
-        img = env.get_full_render()
+        img = env.get_frame()
         redraw(window, img)
 
 

--- a/gym_minigrid/manual_control.py
+++ b/gym_minigrid/manual_control.py
@@ -10,8 +10,8 @@ def redraw(window, img):
     window.show_img(img)
 
 
-def reset(env, window):
-    _ = env.reset()
+def reset(env, window, seed=None):
+    _ = env.reset(seed=seed)
 
     if hasattr(env, "mission"):
         print("Mission: %s" % env.mission)
@@ -99,10 +99,8 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    seed = None if args.seed == -1 else args.seed
     env = gym.make(
         args.env,
-        seed=seed,
         new_step_api=True,
         render_mode="human",  # Note that we do not need to use "human", as Window handles human rendering.
         tile_size=args.tile_size,
@@ -114,8 +112,9 @@ if __name__ == "__main__":
 
     window = Window("gym_minigrid - " + args.env)
     window.reg_key_handler(lambda event: key_handler(env, window, event))
-
-    reset(env, window)
+    
+    seed = None if args.seed == -1 else args.seed
+    reset(env, window, seed)
 
     # Blocking event loop
     window.show(block=True)

--- a/gym_minigrid/minigrid.py
+++ b/gym_minigrid/minigrid.py
@@ -1514,8 +1514,8 @@ class MiniGridEnv(gym.Env):
 
         Args:
 
-            highlight (bool): If true, the agent's field of view or point of view is higlighted with a lighter gray color.
-            tile_size (int): How many pixels will form a tile from the NxM grid. 
+            highlight (bool): If true, the agent's field of view or point of view is highlighted with a lighter gray color.
+            tile_size (int): How many pixels will form a tile from the NxM grid.
             agent_pov (bool): If true, the rendered frame will only contain the point of view of the agent.
 
         Returns:
@@ -1523,7 +1523,7 @@ class MiniGridEnv(gym.Env):
             frame (np.ndarray): A frame of type numpy.ndarray with shape (x, y, 3) representing RGB values for the x-by-y pixel image.
 
         """
-        
+
         if agent_pov:
             return self.get_pov_render(tile_size)
         else:

--- a/gym_minigrid/minigrid.py
+++ b/gym_minigrid/minigrid.py
@@ -926,9 +926,6 @@ class MiniGridEnv(gym.Env):
 
         self.renderer = Renderer(self.render_mode, frame_rendering)
 
-        # Initialize the state
-        self.reset()
-
     def reset(self, *, seed=None, return_info=False, options=None):
         super().reset(seed=seed)
 

--- a/gym_minigrid/minigrid.py
+++ b/gym_minigrid/minigrid.py
@@ -825,9 +825,6 @@ class MiniGridEnv(gym.Env):
     """
 
     metadata = {
-        # Deprecated: use 'render_modes' instead
-        "render.modes": ["human", "rgb_array"],
-        "video.frames_per_second": 10,  # Deprecated: use 'render_fps' instead
         "render_modes": ["human", "rgb_array", "single_rgb_array"],
         "render_fps": 10,
     }

--- a/gym_minigrid/minigrid.py
+++ b/gym_minigrid/minigrid.py
@@ -1510,7 +1510,20 @@ class MiniGridEnv(gym.Env):
         tile_size: int = TILE_PIXELS,
         agent_pov: bool = False,
     ):
-        "Returns an image corresponding to the whole environment or the agent's pov"
+        """Returns an RGB image corresponding to the whole environment or the agent's point of view.
+
+        Args:
+
+            highlight (bool): If true, the agent's field of view or point of view is higlighted with a lighter gray color.
+            tile_size (int): How many pixels will form a tile from the NxM grid. 
+            agent_pov (bool): If true, the rendered frame will only contain the point of view of the agent.
+
+        Returns:
+
+            frame (np.ndarray): A frame of type numpy.ndarray with shape (x, y, 3) representing RGB values for the x-by-y pixel image.
+
+        """
+        
         if agent_pov:
             return self.get_pov_render(tile_size)
         else:

--- a/gym_minigrid/window.py
+++ b/gym_minigrid/window.py
@@ -88,6 +88,5 @@ class Window:
         """
         Close the window
         """
-
         plt.close()
         self.closed = True

--- a/gym_minigrid/wrappers.py
+++ b/gym_minigrid/wrappers.py
@@ -164,10 +164,6 @@ class RGBImgObsWrapper(ObservationWrapper):
     def __init__(self, env, tile_size=8):
         super().__init__(env, new_step_api=env.new_step_api)
 
-        # Rendering attributes
-        self.highlight = True
-        self.tile_size = tile_size
-
         self.tile_size = tile_size
 
         new_image_space = spaces.Box(
@@ -182,7 +178,7 @@ class RGBImgObsWrapper(ObservationWrapper):
         )
 
     def observation(self, obs):
-        rgb_img = self.get_full_render()
+        rgb_img = self.get_frame(highlight=True, tile_size=self.tile_size)
 
         return {**obs, "image": rgb_img}
 
@@ -196,8 +192,7 @@ class RGBImgPartialObsWrapper(ObservationWrapper):
     def __init__(self, env, tile_size=8):
         super().__init__(env, new_step_api=env.new_step_api)
 
-        # Rendering attributes
-        self.unwrapped.agent_pov = True
+        # Rendering attributes for observations
         self.tile_size = tile_size
 
         obs_shape = env.observation_space.spaces["image"].shape
@@ -213,7 +208,7 @@ class RGBImgPartialObsWrapper(ObservationWrapper):
         )
 
     def observation(self, obs):
-        rgb_img_partial = self.get_pov_render()
+        rgb_img_partial = self.get_frame(tile_size=self.tile_size, agent_pov=True)
 
         return {**obs, "image": rgb_img_partial}
 

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -121,12 +121,11 @@ def test_agent_sees_method(env_id):
     env = gym.make(env_id, new_step_api=True)
     goal_pos = (env.grid.width - 2, env.grid.height - 2)
 
+    # Test the env.agent_sees() function
+    env.reset()
     # Test the "in" operator on grid objects
     assert ("green", "goal") in env.grid
     assert ("blue", "key") not in env.grid
-
-    # Test the env.agent_sees() function
-    env.reset()
     for i in range(0, 500):
         action = env.action_space.sample()
         obs, reward, terminated, truncated, info = env.step(action)

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -23,7 +23,7 @@ def test_window():
     caption = "testing caption"
     window.set_caption(caption)
 
-    window.show()
+    window.show(block=False)
 
     window.close()
 


### PR DESCRIPTION
# Description

Add the new `gym` rendering API with the `Render()` method

- Add `Render` class for rendering.
- Changed name of `get_render()` for `get_frame()`
- Make `highlight`, `tile_size`, `agent_pov` optional arguments for `get_frame()`
- Remove `reset()` from `__init__` of `MiniGridEnv` class
- Fix seeding in `manual_control.py`. Seeding was being done in the `step()` as in older versions of gym.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Screenshots
Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |


To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
